### PR TITLE
Update mandrill.js

### DIFF
--- a/lib/mandrill.js
+++ b/lib/mandrill.js
@@ -134,7 +134,7 @@ Mailer.send = function (options, cb) {
       });
 
     }
-    else if (_.isObject(options.to)) {
+    else if (_.isPlainObject(options.to)) {
       mandrilMessage.message.to = [options.to];
     }
     else {


### PR DESCRIPTION
lodash isObject method fails when passing "to" as an array.  Changing this to isPlainObject fixes this.
